### PR TITLE
chore: update lens docs

### DIFF
--- a/docs/pages/ecosystem/lens.mdx
+++ b/docs/pages/ecosystem/lens.mdx
@@ -5,8 +5,8 @@ description: "An extension of Open Graph that makes link previews interactive."
 
 # Lens
 
-Lens Protocol is in the process of adopting Open Frames.
+Open Frames is supported by [Lens Protocol](https://www.lens.xyz/), including apps on Lens like [Buttrfly](https://buttrfly.app/) and [Hey](https://hey.xyz/).
 
 ## Reference
 
-See the [Lens Improvement Proposal](https://github.com/lens-protocol/LIPs/pull/52) for more information on how to use Open Frames with Lens Protocol.
+See the [Lens Frames Docs](https://github.com/defispartan/lens-frames?tab=readme-ov-file#lens-protocol-frames) or [Lens Improvement Proposal](https://github.com/lens-protocol/LIPs/pull/52) for more information on how to use Open Frames with Lens Protocol.


### PR DESCRIPTION
Updates the docs with new lens frames docs. We should wait to merge until 21st June 2024