### PR TITLE
fix: add missing fallback for `of:post_url`

### DIFF
--- a/pages/spec.md
+++ b/pages/spec.md
@@ -140,6 +140,7 @@ The following properties are directly compatible with the following Farcaster pr
 
 | Open Frames Property | Farcaster Property |
 | --- | --- |
+| `of:post_url` | `fc:frame:post_url` |
 | `of:image` | `fc:frame:image` |
 | `og:image` | `og:image` |
 | `of:button:$idx` | `fc:frame:button:index` |


### PR DESCRIPTION
This PR adds missing fallback for `of:post_url`. `of:post_url` falls back to `fc:frame:post_url` if available.